### PR TITLE
Fix ruamel.yaml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 scapy==2.4.0
 pyaml>=17.12.1
-ruamel.yaml==0.15.0
+ruamel.yaml==0.15.54
 


### PR DESCRIPTION
Otherwise fails with:

```
pip3 install .
Processing /Users/gabe/Projects/trackerjacker
Collecting scapy==2.4.0 (from trackerjacker==1.8.7)
  Using cached https://files.pythonhosted.org/packages/68/01/b9943984447e7ea6f8948e90c1729b78161c2bb3eef908430638ec3f7296/scapy-2.4.0.tar.gz
Collecting pyaml>=17.12.1 (from trackerjacker==1.8.7)
  Using cached https://files.pythonhosted.org/packages/17/c1/5892f756109e54ed53c753129b0da4acf6b6add8dff5a85b18667553b16d/pyaml-17.12.1-py2.py3-none-any.whl
Collecting ruamel.yaml==0.15.0 (from trackerjacker==1.8.7)
  Using cached https://files.pythonhosted.org/packages/10/aa/f31c8a858e23fe5b14c59e6a03ae80b4cb76353c184df48a582a55eb2674/ruamel.yaml-0.15.0.tar.gz
    Complete output from command python setup.py egg_info:
    /var/folders/84/7q50__3j4yscqtt4qmrv8rtr0000gn/T/tmp_ruamel_146zzgcq/test_ruamel_yaml.c:6:8: warning: explicitly assigning value of variable of type 'yaml_parser_t' (aka 'struct yaml_parser_s') to itself [-Wself-assign]
    parser = parser;  /* prevent warning */
    ~~~~~~ ^ ~~~~~~
    /var/folders/84/7q50__3j4yscqtt4qmrv8rtr0000gn/T/tmp_ruamel_146zzgcq/test_ruamel_yaml.c:6:10: warning: variable 'parser' is uninitialized when used here [-Wuninitialized]
    parser = parser;  /* prevent warning */
             ^~~~~~
    /var/folders/84/7q50__3j4yscqtt4qmrv8rtr0000gn/T/tmp_ruamel_146zzgcq/test_ruamel_yaml.c:5:1: note: variable 'parser' is declared here
    yaml_parser_t parser;
    ^
    2 warnings generated.
    Warning: 'keywords' should be a list, got type 'NoneType'
    sys.argv ['-c', 'egg_info', '--egg-base', 'pip-egg-info']
    test compiling test_ruamel_yaml
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/84/7q50__3j4yscqtt4qmrv8rtr0000gn/T/pip-install-hbxr4h7y/ruamel.yaml/setup.py", line 858, in <module>
        main()
      File "/private/var/folders/84/7q50__3j4yscqtt4qmrv8rtr0000gn/T/pip-install-hbxr4h7y/ruamel.yaml/setup.py", line 847, in main
        setup(**kw)
      File "/usr/local/lib/python3.7/site-packages/setuptools/__init__.py", line 129, in setup
        return distutils.core.setup(**attrs)
      File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/distutils/core.py", line 108, in setup
        _setup_distribution = dist = klass(attrs)
      File "/usr/local/lib/python3.7/site-packages/setuptools/dist.py", line 370, in __init__
        k: v for k, v in attrs.items()
      File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/distutils/dist.py", line 267, in __init__
        getattr(self.metadata, "set_" + key)(val)
      File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/distutils/dist.py", line 1203, in set_keywords
        self.keywords = _ensure_list(value, 'keywords')
      File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/distutils/dist.py", line 40, in _ensure_list
        value = list(value)
    TypeError: 'NoneType' object is not iterable
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/84/7q50__3j4yscqtt4qmrv8rtr0000gn/T/pip-install-hbxr4h7y/ruamel.yaml/
```